### PR TITLE
DOC: Fix API doc on RTD

### DIFF
--- a/pandas_ml/compat.py
+++ b/pandas_ml/compat.py
@@ -2,8 +2,15 @@
 
 from distutils.version import LooseVersion
 
-import sklearn
-_SKLEARN_ge_017 = sklearn.__version__ >= LooseVersion('0.17.0')
+try:
+    import sklearn
+    _SKLEARN_INSTALLED = True
+    _SKLEARN_ge_017 = sklearn.__version__ >= LooseVersion('0.17.0')
+
+except ImportError:
+    _SKLEARN_INSTALLED = False
+    _SKLEARN_ge_017 = False
+
 
 try:
     import imblearn                 # noqa

--- a/pandas_ml/confusion_matrix/abstract.py
+++ b/pandas_ml/confusion_matrix/abstract.py
@@ -3,8 +3,6 @@
 
 import numpy as np
 import pandas as pd
-# import matplotlib as mpl
-import matplotlib.pylab as plt
 import collections
 
 from pandas_ml.confusion_matrix.stats import binom_interval, class_agreement, prop_test
@@ -212,6 +210,9 @@ class ConfusionMatrixAbstract(object):
         """
         Plots confusion matrix
         """
+
+        import matplotlib.pylab as plt
+
         df = self.to_dataframe(normalized)
 
         try:

--- a/pandas_ml/confusion_matrix/stats.py
+++ b/pandas_ml/confusion_matrix/stats.py
@@ -2,20 +2,16 @@
 # -*- coding: utf8 -*-
 
 import numpy as np
-import scipy
-from scipy.stats import beta
-
-
-try:
-    xrange
-except NameError:
-    xrange = range
+from pandas.compat import range
 
 
 def binom_interval(success, total, confint=0.95):
     """
     Compute two-sided binomial confidence interval in Python. Based on R's binom.test.
     """
+
+    from scipy.stats import beta
+
     quantile = (1 - confint) / 2.
     lower = beta.ppf(quantile, success, total - success + 1)
     upper = beta.ppf(1 - quantile, success + 1, total - success)
@@ -29,7 +25,7 @@ def choose(n, k):
     if 0 <= k <= n:
         ntok = 1
         ktok = 1
-        for t in xrange(1, min(k, n - k) + 1):
+        for t in range(1, min(k, n - k) + 1):
             ntok *= n
             ktok *= t
             n -= 1
@@ -72,6 +68,8 @@ def prop_test(df):
     """
     Inspired from R package caret confusionMatrix.R
     """
+    from scipy.stats import binom
+
     x = np.diag(df).sum()
     n = df.sum().sum()
     p = (df.sum(axis=0) / df.sum().sum()).max()
@@ -79,6 +77,6 @@ def prop_test(df):
         "statistic": x,  # number of successes
         "parameter": n,  # number of trials
         "null.value": p,  # probability of success
-        "p.value": scipy.stats.binom.sf(x - 1, n, p),  # see https://en.wikipedia.org/wiki/Binomial_test
+        "p.value": binom.sf(x - 1, n, p),  # see https://en.wikipedia.org/wiki/Binomial_test
     }
     return(d)

--- a/pandas_ml/core/base.py
+++ b/pandas_ml/core/base.py
@@ -1,9 +1,28 @@
 #!/usr/bin/env python
 
-import sklearn.base as base
+try:
+    import sklearn.base as base
 
-_BaseEstimator = base.BaseEstimator
-_ClassifierMixin = base.ClassifierMixin
-_ClusterMixin = base.ClusterMixin
-_RegressorMixin = base.RegressorMixin
-_TransformerMixin = base.TransformerMixin
+    _BaseEstimator = base.BaseEstimator
+    _ClassifierMixin = base.ClassifierMixin
+    _ClusterMixin = base.ClusterMixin
+    _RegressorMixin = base.RegressorMixin
+    _TransformerMixin = base.TransformerMixin
+
+except ImportError:
+    # for ReadTheDoc, unable to use mock because of metaclass
+
+    class _BaseEstimator(object):
+        pass
+
+    class _ClassifierMixin(object):
+        pass
+
+    class _ClusterMixin(object):
+        pass
+
+    class _RegressorMixin(object):
+        pass
+
+    class _TransformerMixin(object):
+        pass

--- a/pandas_ml/skaccessors/base.py
+++ b/pandas_ml/skaccessors/base.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python
 
-from sklearn.datasets.base import Bunch
-
 import pandas as pd
+
+try:
+    from sklearn.datasets.base import Bunch
+except ImportError:
+
+    class Bunch(object):
+        pass
 
 
 def _maybe_sklearn_data(data, target):

--- a/pandas_ml/skaccessors/preprocessing.py
+++ b/pandas_ml/skaccessors/preprocessing.py
@@ -4,28 +4,34 @@ import numpy as np
 import pandas as pd
 
 from pandas_ml.core.accessor import _AccessorMethods, _attach_methods
-from pandas_ml.compat import _SKLEARN_ge_017
+from pandas_ml.compat import _SKLEARN_INSTALLED, _SKLEARN_ge_017
 
-import sklearn.preprocessing as pp
-if _SKLEARN_ge_017:
-    _keep_col_classes = [pp.Binarizer,
-                         pp.FunctionTransformer,
-                         pp.Imputer,
-                         pp.KernelCenterer,
-                         pp.LabelEncoder,
-                         pp.MaxAbsScaler,
-                         pp.MinMaxScaler,
-                         pp.Normalizer,
-                         pp.RobustScaler,
-                         pp.StandardScaler]
+
+if _SKLEARN_INSTALLED:
+
+    import sklearn.preprocessing as pp
+
+    if _SKLEARN_ge_017:
+        _keep_col_classes = [pp.Binarizer,
+                             pp.FunctionTransformer,
+                             pp.Imputer,
+                             pp.KernelCenterer,
+                             pp.LabelEncoder,
+                             pp.MaxAbsScaler,
+                             pp.MinMaxScaler,
+                             pp.Normalizer,
+                             pp.RobustScaler,
+                             pp.StandardScaler]
+    else:
+        _keep_col_classes = [pp.Binarizer,
+                             pp.Imputer,
+                             pp.KernelCenterer,
+                             pp.LabelEncoder,
+                             pp.MinMaxScaler,
+                             pp.Normalizer,
+                             pp.StandardScaler]
 else:
-    _keep_col_classes = [pp.Binarizer,
-                         pp.Imputer,
-                         pp.KernelCenterer,
-                         pp.LabelEncoder,
-                         pp.MinMaxScaler,
-                         pp.Normalizer,
-                         pp.StandardScaler]
+    _keep_col_classes = []
 
 
 class PreprocessingMethods(_AccessorMethods):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pandas >= 0.17.0
-scikit-learn >= 0.16.0
 enum34


### PR DESCRIPTION
To build API doc, sklearn, scipy and matplotlib deps should be optional. Not sure there is a better way...


**Build result (non-public):**
- http://pandas-ml.readthedocs.io/en/mock/generated/pandas_ml.skaccessors.html