### PR TITLE
API: Add .model_selection.split, deprecate .iterate

### DIFF
--- a/doc/source/sklearn.rst
+++ b/doc/source/sklearn.rst
@@ -317,7 +317,7 @@ Cross Validation
    [38 rows x 5 columns]
 
 
-You can iterate over Splitter classes via ``ModelFrame.model_selection.iterate`` which returns ``ModelFrame`` corresponding to training and test data.
+You can iterate over Splitter classes via ``ModelFrame.model_selection.split`` which returns ``ModelFrame`` corresponding to training and test data.
 
 .. code-block:: python
 

--- a/pandas_ml/core/frame.py
+++ b/pandas_ml/core/frame.py
@@ -576,14 +576,14 @@ class ModelFrame(pd.DataFrame, ModelPredictor):
     @Appender(_shared_docs['skaccessor'] % dict(module='cross_validation'))
     def cross_validation(self):
         msg = '.cross_validation is deprecated. Use .ms or .model_selection'
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        warnings.warn(msg, FutureWarning, stacklevel=2)
         return self._cross_validation
 
     @property
     @Appender(_shared_docs['skaccessor'] % dict(module='cross_validation'))
     def crv(self):
         msg = '.crv is deprecated. Use .ms or .model_selection'
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        warnings.warn(msg, FutureWarning, stacklevel=2)
         return self._cross_validation
 
     @cache_readonly
@@ -671,7 +671,7 @@ class ModelFrame(pd.DataFrame, ModelPredictor):
     @Appender(_shared_docs['skaccessor'] % dict(module='grid_search'))
     def grid_search(self):
         msg = '.grid_search is deprecated. Use .ms or .model_selection'
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        warnings.warn(msg, FutureWarning, stacklevel=2)
         return self._grid_search
 
     @cache_readonly
@@ -722,14 +722,14 @@ class ModelFrame(pd.DataFrame, ModelPredictor):
     @Appender(_shared_docs['skaccessor_nolink'] % dict(module='lda'))
     def lda(self):
         msg = '.lda is deprecated. Use .da or .diccriminant_analysis'
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        warnings.warn(msg, FutureWarning, stacklevel=2)
         return self._da
 
     @property
     @Appender(_shared_docs['skaccessor'] % dict(module='learning_curve'))
     def learning_curve(self):
         msg = '.learning_curve is deprecated. Use .ms or .model_selection'
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        warnings.warn(msg, FutureWarning, stacklevel=2)
         return self._learning_curve
 
     @cache_readonly
@@ -863,7 +863,7 @@ class ModelFrame(pd.DataFrame, ModelPredictor):
     @Appender(_shared_docs['skaccessor_nolink'] % dict(module='qda'))
     def qda(self):
         msg = '.qda is deprecated. Use .da or .diccriminant_analysis'
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        warnings.warn(msg, FutureWarning, stacklevel=2)
         return self._da
 
     @property

--- a/pandas_ml/skaccessors/model_selection.py
+++ b/pandas_ml/skaccessors/model_selection.py
@@ -29,7 +29,7 @@ class ModelSelectionMethods(_AccessorMethods):
             target = self._target
             return self._module.StratifiedShuffleSplit(target.values, *args, **kwargs)
 
-    def iterate(self, cv, reset_index=False):
+    def split(self, cv, reset_index=False):
         """
         Generate ``ModelFrame`` using iterators for cross validation
 
@@ -73,6 +73,12 @@ class ModelSelectionMethods(_AccessorMethods):
                     train_df = train_df.reset_index(drop=True)
                     test_df = test_df.reset_index(drop=True)
                 yield train_df, test_df
+
+    def iterate(self, cv, reset_index=False):
+        """ deprecated. Use .split """
+        warnings.warn(".iterate is deprecated. Use .split instead",
+                      FutureWarning, stacklevel=2)
+        return self.split(cv, reset_index=reset_index)
 
     # Splitter Functions
 

--- a/pandas_ml/skaccessors/test/test_discriminant_analysis.py
+++ b/pandas_ml/skaccessors/test/test_discriminant_analysis.py
@@ -31,10 +31,10 @@ class TestDiscriminantAnalysis(tm.TestCase):
 
     def test_objectmapper_deprecated(self):
         df = pdml.ModelFrame([])
-        with tm.assert_produces_warning(DeprecationWarning):
+        with tm.assert_produces_warning(FutureWarning):
             self.assertIs(df.lda.LinearDiscriminantAnalysis,
                           da.LinearDiscriminantAnalysis)
-        with tm.assert_produces_warning(DeprecationWarning):
+        with tm.assert_produces_warning(FutureWarning):
             self.assertIs(df.qda.QuadraticDiscriminantAnalysis,
                           da.QuadraticDiscriminantAnalysis)
 


### PR DESCRIPTION
To be compat with ``sklearn`` 0.18, rename ``model_selection.iterate`` to ``.split``.