### PR TITLE
Alternate MCC forumla to fix for numpy int64 overflows

### DIFF
--- a/pandas_ml/confusion_matrix/bcm.py
+++ b/pandas_ml/confusion_matrix/bcm.py
@@ -305,7 +305,7 @@ len=%d because y_true.unique()=%s y_pred.unique()=%s" \
         N = self.TN + self.TP + self.FN + self.FP
         S = (self.TP + self.FN) / N
         P = (self.TP + self.FP) / N
-        return ((self.TP/N) - (S*P)) / math.sqrt(P*S*(1-S)*(1-P))
+        return ((self.TP / N) - (S * P)) / math.sqrt(P * S * (1 - S) * (1 - P))
 
     @property
     def informedness(self):

--- a/pandas_ml/confusion_matrix/bcm.py
+++ b/pandas_ml/confusion_matrix/bcm.py
@@ -296,12 +296,16 @@ len=%d because y_true.unique()=%s y_pred.unique()=%s" \
     def MCC(self):
         """
         Matthews correlation coefficient (MCC)
-        \frac{ TP \times TN - FP \times FN }
-             {\sqrt{ (TP+FP) ( TP + FN ) ( TN + FP ) ( TN + FN ) }
+        N = TN + TP + FN + FP
+        S = \frac{\left(TP + FN\right)}{N}
+        P = \frac{\left(TP + FP\right)}{N}
+        MCC = \frac{\frac{TP}{N} - \left(S \times P\right)}
+              {\sqrt{PS\left(1 - S\right)\left(1 - P\right)}}
         """
-        return((self.TP * self.TN - self.FP * self.FN) /
-               math.sqrt((self.TP + self.FP) * (self.TP + self.FN) *
-               (self.TN + self.FP) * (self.TN + self.FN)))
+        N = self.TN + self.TP + self.FN + self.FP
+        S = (self.TP + self.FN) / N
+        P = (self.TP + self.FP) / N
+        return ((self.TP/N) - (S*P)) / math.sqrt(P*S*(1-S)*(1-P))
 
     @property
     def informedness(self):


### PR DESCRIPTION
Fix for #105.

Tested by comparing the old formula and the new formula and received exactly the same results. Interestingly the overflow doesn't occur with the standard python ints but only the numpy int64 types.