### PR TITLE
Fixed imports of deprecated modules which were removed in pandas 0.24.0

### DIFF
--- a/pandas_ml/core/frame.py
+++ b/pandas_ml/core/frame.py
@@ -7,12 +7,6 @@ import numpy as np
 import pandas as pd
 import pandas.compat as compat
 
-version = LooseVersion(pd.__version__)
-if version < '0.21.0':
-    from pandas.util.decorators import Appender, cache_readonly
-else:
-    from pandas.util import Appender, cache_readonly
-
 from pandas_ml.compat import is_list_like
 from pandas_ml.core.generic import ModelPredictor, _shared_docs
 from pandas_ml.core.series import ModelSeries
@@ -23,6 +17,12 @@ import pandas_ml.smaccessors as smaccessors
 import pandas_ml.snsaccessors as snsaccessors
 import pandas_ml.xgboost as xgboost
 import pandas_ml.util as util
+
+version = LooseVersion(pd.__version__)
+if version < '0.21.0':
+    from pandas.util.decorators import Appender, cache_readonly
+else:
+    from pandas.util import Appender, cache_readonly
 
 
 class ModelFrame(ModelPredictor, pd.DataFrame):

--- a/pandas_ml/core/frame.py
+++ b/pandas_ml/core/frame.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 import pandas as pd
 import pandas.compat as compat
-from pandas.util.decorators import Appender, cache_readonly
+from pandas.util import Appender, cache_readonly
 
 from pandas_ml.compat import is_list_like
 from pandas_ml.core.generic import ModelPredictor, _shared_docs

--- a/pandas_ml/core/frame.py
+++ b/pandas_ml/core/frame.py
@@ -1,25 +1,23 @@
 #!/usr/bin/env python
 
 import warnings
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
 import pandas.compat as compat
 
-from pandas_ml.compat import is_list_like
-from pandas_ml.core.generic import ModelPredictor, _shared_docs
-from pandas_ml.core.series import ModelSeries
-from pandas_ml.core.accessor import _AccessorMethods
 import pandas_ml.imbaccessors as imbaccessors
 import pandas_ml.skaccessors as skaccessors
 import pandas_ml.smaccessors as smaccessors
 import pandas_ml.snsaccessors as snsaccessors
-import pandas_ml.xgboost as xgboost
 import pandas_ml.util as util
+import pandas_ml.xgboost as xgboost
+from pandas_ml.compat import is_list_like, _PANDAS_ge_021
+from pandas_ml.core.accessor import _AccessorMethods
+from pandas_ml.core.generic import ModelPredictor, _shared_docs
+from pandas_ml.core.series import ModelSeries
 
-version = LooseVersion(pd.__version__)
-if version < '0.21.0':
+if not _PANDAS_ge_021:
     from pandas.util.decorators import Appender, cache_readonly
 else:
     from pandas.util import Appender, cache_readonly

--- a/pandas_ml/core/generic.py
+++ b/pandas_ml/core/generic.py
@@ -3,7 +3,7 @@
 import warnings
 
 import pandas.compat as compat
-from pandas.util.decorators import Appender
+from pandas.util import Appender
 
 import pandas_ml.misc as misc
 

--- a/pandas_ml/core/generic.py
+++ b/pandas_ml/core/generic.py
@@ -4,16 +4,15 @@ import warnings
 from distutils.version import LooseVersion
 
 import pandas.compat as compat
-
 from pandas import __version__
+
+import pandas_ml.misc as misc
+
 version = LooseVersion(__version__)
 if version < '0.21.0':
     from pandas.util.decorators import Appender
 else:
     from pandas.util import Appender
-
-import pandas_ml.misc as misc
-
 
 _shared_docs = dict()
 

--- a/pandas_ml/core/generic.py
+++ b/pandas_ml/core/generic.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 
 import warnings
-from distutils.version import LooseVersion
 
 import pandas.compat as compat
-from pandas import __version__
 
 import pandas_ml.misc as misc
+from pandas_ml.compat import _PANDAS_ge_021
 
-version = LooseVersion(__version__)
-if version < '0.21.0':
+if not _PANDAS_ge_021:
     from pandas.util.decorators import Appender
 else:
     from pandas.util import Appender

--- a/pandas_ml/core/groupby.py
+++ b/pandas_ml/core/groupby.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import pandas as pd
-from pandas.util.decorators import Appender
+from pandas.util import Appender
 import pandas.compat as compat
 
 from pandas_ml.core.base import _BaseEstimator

--- a/pandas_ml/core/groupby.py
+++ b/pandas_ml/core/groupby.py
@@ -3,18 +3,18 @@
 from distutils.version import LooseVersion
 
 import pandas as pd
+import pandas.compat as compat
+
+from pandas_ml.core.base import _BaseEstimator
+from pandas_ml.core.frame import ModelFrame
+from pandas_ml.core.generic import ModelPredictor, _shared_docs
+from pandas_ml.core.series import ModelSeries
 
 version = LooseVersion(pd.__version__)
 if version < '0.21.0':
     from pandas.util.decorators import Appender
 else:
     from pandas.util import Appender
-import pandas.compat as compat
-
-from pandas_ml.core.base import _BaseEstimator
-from pandas_ml.core.generic import ModelPredictor, _shared_docs
-from pandas_ml.core.frame import ModelFrame
-from pandas_ml.core.series import ModelSeries
 
 
 @Appender(pd.core.groupby.GroupBy.__doc__)

--- a/pandas_ml/core/groupby.py
+++ b/pandas_ml/core/groupby.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python
 
-from distutils.version import LooseVersion
-
 import pandas as pd
 import pandas.compat as compat
 
+from pandas_ml.compat import _PANDAS_ge_021
 from pandas_ml.core.base import _BaseEstimator
 from pandas_ml.core.frame import ModelFrame
 from pandas_ml.core.generic import ModelPredictor, _shared_docs
 from pandas_ml.core.series import ModelSeries
 
-version = LooseVersion(pd.__version__)
-if version < '0.21.0':
+if not _PANDAS_ge_021:
     from pandas.util.decorators import Appender
 else:
     from pandas.util import Appender

--- a/pandas_ml/core/series.py
+++ b/pandas_ml/core/series.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import pandas as pd
-from pandas.util.decorators import Appender, cache_readonly
+from pandas.util import Appender, cache_readonly
 
 from pandas_ml.core.generic import ModelTransformer, _shared_docs
 import pandas_ml.skaccessors as skaccessors

--- a/pandas_ml/core/series.py
+++ b/pandas_ml/core/series.py
@@ -1,16 +1,13 @@
 #!/usr/bin/env python
 
-from distutils.version import LooseVersion
-
 import pandas as pd
-from pandas import __version__
 
 import pandas_ml.skaccessors as skaccessors
 import pandas_ml.util as util
+from pandas_ml.compat import _PANDAS_ge_021
 from pandas_ml.core.generic import ModelTransformer, _shared_docs
 
-version = LooseVersion(__version__)
-if version < '0.21.0':
+if not _PANDAS_ge_021:
     from pandas.util.decorators import Appender, cache_readonly
 else:
     from pandas.util import Appender, cache_readonly

--- a/pandas_ml/core/series.py
+++ b/pandas_ml/core/series.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python
 
-import pandas as pd
-from pandas.util import Appender, cache_readonly
+from distutils.version import LooseVersion
 
-from pandas_ml.core.generic import ModelTransformer, _shared_docs
+import pandas as pd
+from pandas import __version__
+
 import pandas_ml.skaccessors as skaccessors
 import pandas_ml.util as util
+from pandas_ml.core.generic import ModelTransformer, _shared_docs
+
+version = LooseVersion(__version__)
+if version < '0.21.0':
+    from pandas.util.decorators import Appender, cache_readonly
+else:
+    from pandas.util import Appender, cache_readonly
 
 
 class ModelSeries(ModelTransformer, pd.Series):

--- a/pandas_ml/imbaccessors/base.py
+++ b/pandas_ml/imbaccessors/base.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 
-from pandas.util.decorators import cache_readonly
+from pandas.util import cache_readonly
 
 from pandas_ml.core.accessor import _AccessorMethods
 

--- a/pandas_ml/imbaccessors/base.py
+++ b/pandas_ml/imbaccessors/base.py
@@ -3,13 +3,14 @@
 from distutils.version import LooseVersion
 
 from pandas import __version__
+
+from pandas_ml.core.accessor import _AccessorMethods
+
 version = LooseVersion(__version__)
 if version < '0.21.0':
     from pandas.util.decorators import cache_readonly
 else:
     from pandas.util import cache_readonly
-
-from pandas_ml.core.accessor import _AccessorMethods
 
 
 class ImbalanceMethods(_AccessorMethods):

--- a/pandas_ml/imbaccessors/base.py
+++ b/pandas_ml/imbaccessors/base.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python
 
-from distutils.version import LooseVersion
-
-from pandas import __version__
-
+from pandas_ml.compat import _PANDAS_ge_021
 from pandas_ml.core.accessor import _AccessorMethods
 
-version = LooseVersion(__version__)
-if version < '0.21.0':
+if not _PANDAS_ge_021:
     from pandas.util.decorators import cache_readonly
 else:
     from pandas.util import cache_readonly

--- a/pandas_ml/skaccessors/cluster.py
+++ b/pandas_ml/skaccessors/cluster.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from pandas.util.decorators import cache_readonly
+from pandas.util import cache_readonly
 
 from pandas_ml.core.accessor import _AccessorMethods, _attach_methods, _wrap_data_func
 

--- a/pandas_ml/skaccessors/cluster.py
+++ b/pandas_ml/skaccessors/cluster.py
@@ -3,13 +3,14 @@
 from distutils.version import LooseVersion
 
 from pandas import __version__
+
+from pandas_ml.core.accessor import _AccessorMethods, _attach_methods, _wrap_data_func
+
 version = LooseVersion(__version__)
 if version < '0.21.0':
     from pandas.util.decorators import cache_readonly
 else:
     from pandas.util import cache_readonly
-
-from pandas_ml.core.accessor import _AccessorMethods, _attach_methods, _wrap_data_func
 
 
 class ClusterMethods(_AccessorMethods):

--- a/pandas_ml/skaccessors/cluster.py
+++ b/pandas_ml/skaccessors/cluster.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python
 
-from distutils.version import LooseVersion
-
-from pandas import __version__
-
+from pandas_ml.compat import _PANDAS_ge_021
 from pandas_ml.core.accessor import _AccessorMethods, _attach_methods, _wrap_data_func
 
-version = LooseVersion(__version__)
-if version < '0.21.0':
+if not _PANDAS_ge_021:
     from pandas.util.decorators import cache_readonly
 else:
     from pandas.util import cache_readonly

--- a/pandas_ml/skaccessors/feature_extraction.py
+++ b/pandas_ml/skaccessors/feature_extraction.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 
-from pandas.util.decorators import cache_readonly
+from pandas.util import cache_readonly
 
 from pandas_ml.core.accessor import _AccessorMethods
 

--- a/pandas_ml/skaccessors/feature_extraction.py
+++ b/pandas_ml/skaccessors/feature_extraction.py
@@ -3,13 +3,14 @@
 from distutils.version import LooseVersion
 
 from pandas import __version__
+
+from pandas_ml.core.accessor import _AccessorMethods
+
 version = LooseVersion(__version__)
 if version < '0.21.0':
     from pandas.util.decorators import cache_readonly
 else:
     from pandas.util import cache_readonly
-
-from pandas_ml.core.accessor import _AccessorMethods
 
 
 class FeatureExtractionMethods(_AccessorMethods):

--- a/pandas_ml/skaccessors/feature_extraction.py
+++ b/pandas_ml/skaccessors/feature_extraction.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python
 
-from distutils.version import LooseVersion
-
-from pandas import __version__
-
+from pandas_ml.compat import _PANDAS_ge_021
 from pandas_ml.core.accessor import _AccessorMethods
 
-version = LooseVersion(__version__)
-if version < '0.21.0':
+if not _PANDAS_ge_021:
     from pandas.util.decorators import cache_readonly
 else:
     from pandas.util import cache_readonly

--- a/pandas_ml/skaccessors/model_selection.py
+++ b/pandas_ml/skaccessors/model_selection.py
@@ -48,12 +48,12 @@ class ModelSelectionMethods(_AccessorMethods):
             gen = cv.split(self._df.index)
 
         for train_index, test_index in gen:
-                train_df = self._df.iloc[train_index, :]
-                test_df = self._df.iloc[test_index, :]
-                if reset_index:
-                    train_df = train_df.reset_index(drop=True)
-                    test_df = test_df.reset_index(drop=True)
-                yield train_df, test_df
+            train_df = self._df.iloc[train_index, :]
+            test_df = self._df.iloc[test_index, :]
+            if reset_index:
+                train_df = train_df.reset_index(drop=True)
+                test_df = test_df.reset_index(drop=True)
+            yield train_df, test_df
 
     def iterate(self, cv, reset_index=False):
         """ deprecated. Use .split """

--- a/pandas_ml/util/testing.py
+++ b/pandas_ml/util/testing.py
@@ -9,7 +9,7 @@ from pandas.util.testing import (assert_produces_warning,           # noqa
                                  assert_series_equal,               # noqa
                                  assert_frame_equal,                # noqa
                                  assert_numpy_array_equal)          # noqa
-import pandas.tools.plotting as plotting
+import pandas.plotting as plotting
 
 
 try:

--- a/pandas_ml/util/testing.py
+++ b/pandas_ml/util/testing.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
-from distutils.version import LooseVersion
-
 import numpy as np
 import pandas.util.testing as tm
 
+from pandas_ml.compat import _PANDAS_ge_021
 from pandas.util.testing import (assert_produces_warning,           # noqa
                                  close, RNGContext,                 # noqa
                                  assert_index_equal,                # noqa
@@ -12,9 +11,8 @@ from pandas.util.testing import (assert_produces_warning,           # noqa
                                  assert_frame_equal,                # noqa
                                  assert_numpy_array_equal)          # noqa
 
-from pandas import __version__
-version = LooseVersion(__version__)
-if version < '0.21.0':
+
+if not _PANDAS_ge_021:
     import pandas.tools.plotting as plotting
 else:
     import pandas.plotting as plotting


### PR DESCRIPTION
Certain functions were deprecated in a previous version of pandas and moved to a different module (see #117). This PR fixes the imports of those functions. 